### PR TITLE
Only handle errors in getAppAccessToken, not the callback's

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ function FBApi(appId, appSecret, permissions, api, cb) {
   this.gettingAppToken = false;
 
   var callback = (cb) ? cb : function(){};
-  this.getAppAccessToken().then(callback).catch(function (e) {
+  this.getAppAccessToken().then(callback, function (e) {
     throw new Error("could not get app access token");
   });
 }


### PR DESCRIPTION
`act().then(foo).catch(bar)` will catch errors in `foo` too, but `bar` only refers to errors in `act` in your case
